### PR TITLE
Bind the scheduler to all of the interfaces

### DIFF
--- a/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
+++ b/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{k8s_scheduler_conf_dir}}/kube-scheduler.kubeconfig"
-healthzBindAddress: {{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}:10251
+healthzBindAddress: 0,0,0,0:10251
 leaderElection:
   leaderElect: true
-metricsBindAddress: {{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}:10251
+metricsBindAddress: 0,0,0,0:10251


### PR DESCRIPTION
This allows the command `kubectl get componentstatuses` to work from a controller.

I'm not sure about what else it would do that would be undesirable, but this does let the above command complete with output that is good.