### PR TITLE
allocate-node-cidrs / 1.18.6 / change delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+**12.1.0+1.18.6**
+
+- update `k8s_release` to `1.18.6`
+- added `"allocate-node-cidrs": "true"" to `k8s_controller_manager_settings` otherwise `cluster-cidr` setting won't be used by `kube-controller-manager`
+- creating ClusterRole's and ClusterRoleBindings is now delegated to `127.0.0.1` (localhost) instead of picking the first Kubernetes controller node for that task
+
 **12.0.1+1.18.5**
 
 - added Ubuntu 20.04 (Focal Fossa) as supported platform

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ k8s_controller_manager_settings:
   "bind-address": "{{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}"
   "secure-port": "10257"
   "cluster-cidr": "10.200.0.0/16"
+  "allocate-node-cidrs": "true"
   "cluster-name": "kubernetes"
   "kubeconfig": "{{k8s_controller_manager_conf_dir}}/kube-controller-manager.kubeconfig"
   "leader-elect": "true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 # The directory to store the K8s binaries
 k8s_bin_dir: "/usr/local/bin"
 # K8s release
-k8s_release: "1.18.5"
+k8s_release: "1.18.6"
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is
 # normally "wg0" (WireGuard),"peervpn0" (PeerVPN) or "tap0".

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,7 @@ k8s_controller_manager_settings:
   "bind-address": "{{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}"
   "secure-port": "10257"
   "cluster-cidr": "10.200.0.0/16"
+  "allocate-node-cidrs": "true"
   "cluster-name": "kubernetes"
   "kubeconfig": "{{k8s_controller_manager_conf_dir}}/kube-controller-manager.kubeconfig"
   "leader-elect": "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -213,7 +213,7 @@
     dest: "/tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
     mode: 0600
   run_once: true
-  delegate_to: "{{ groups.k8s_controller|first }}"
+  delegate_to: 127.0.0.1
   tags:
     - k8s-controller
 
@@ -223,7 +223,7 @@
     dest: "/tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
     mode: 0600
   run_once: true
-  delegate_to: "{{ groups.k8s_controller|first }}"
+  delegate_to: 127.0.0.1
   tags:
     - k8s-controller
 
@@ -236,18 +236,18 @@
   delegate_to: "{{ groups.k8s_controller|first }}"
 
 - name: Apply kube-apiserver-to-kubelet ClusterRole
-  shell: "kubectl apply --kubeconfig {{ k8s_conf_dir }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
+  shell: "kubectl apply --kubeconfig {{ k8s_config_directory }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
   register: kube_apiserver_to_kubelet_cluster_role
   run_once: true
-  delegate_to: "{{ groups.k8s_controller|first }}"
+  delegate_to: 127.0.0.1
   tags:
     - k8s-controller
 
 - name: Apply kube-apiserver-to-kubelet ClusterRoleBinding
-  shell: "kubectl apply --kubeconfig {{ k8s_conf_dir }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
+  shell: "kubectl apply --kubeconfig {{ k8s_config_directory }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
   register: kube_apiserver_to_kubelet_cluster_role_binding
   run_once: true
-  delegate_to: "{{ groups.k8s_controller|first }}"
+  delegate_to: 127.0.0.1
   tags:
     - k8s-controller
 
@@ -259,6 +259,6 @@
     - "/tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
     - "/tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
   run_once: true
-  delegate_to: "{{ groups.k8s_controller|first }}"
+  delegate_to: 127.0.0.1
   tags:
     - k8s-controller


### PR DESCRIPTION
- update `k8s_release` to `1.18.6`
- added `"allocate-node-cidrs": "true"" to `k8s_controller_manager_settings` otherwise `cluster-cidr` setting won't be used by `kube-controller-manager`
- creating ClusterRole's and ClusterRoleBindings is now delegated to `127.0.0.1` (localhost) instead of picking the first Kubernetes controller node for that task
