### PR TITLE
Update to Kubernetes v1.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16.1.0+1.22.6
+
+- update `k8s_release` to `1.22.6`
+
 ## 16.0.0+1.22.5
 
 - update `k8s_release` to `1.22.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 16.1.0+1.22.6
 
 - update `k8s_release` to `1.22.6`
+- use `kubescheduler.config.k8s.io/v1beta2` in `templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2` (`v1beta1` will be removed in Kubernetes v1.23 - see [Remove scheduler policy config and cc v1beta1](https://github.com/kubernetes/enhancements/issues/2901)
 
 ## 16.0.0+1.22.5
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.22.5"
+k8s_release: "1.22.6"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.22.5"
+k8s_release: "1.22.6"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
+++ b/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks:False
-apiVersion: kubescheduler.config.k8s.io/v1beta1
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{k8s_scheduler_conf_dir}}/kube-scheduler.kubeconfig"

--- a/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
+++ b/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks:False
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{k8s_scheduler_conf_dir}}/kube-scheduler.kubeconfig"


### PR DESCRIPTION
- update `k8s_release` to `1.22.6`
- use `kubescheduler.config.k8s.io/v1beta2` in `templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2` (`v1beta1` will be removed in Kubernetes v1.23 - see [Remove scheduler policy config and cc v1beta1](https://github.com/kubernetes/enhancements/issues/2901)