### PR TITLE
introduce k8s_controller_delegate_to variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 19.1.0+1.25.5
+
+- Introduce `k8s_controller_delegate_to` variable. By default it's set to `127.0.0.1` and reflects the same value as before.
+
 ## 19.0.0+1.25.5
 
 - update `k8s_release` to `1.25.5`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ k8s_scheduler_settings:
   "authorization-kubeconfig": "{{k8s_scheduler_conf_dir}}/kube-scheduler.kubeconfig
   "requestheader-client-ca-file": "{{k8s_conf_dir}}/ca-k8s-apiserver.pem"
 
+# By default all tasks that needs to communicate with the Kubernetes
+# cluster are executed on local host (127.0.0.1). But if that one
+# doesn't have direct connection to the K8s cluster or should be executed
+# elsewhere this variable can be changed accordingly.
+k8s_controller_delegate_to: 127.0.0.1
+
 # The port the control plane components should connect to etcd cluster
 etcd_client_port: "2379"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,12 @@ k8s_scheduler_settings:
   "authorization-kubeconfig": "{{ k8s_scheduler_conf_dir }}/kube-scheduler.kubeconfig"
   "requestheader-client-ca-file": "{{ k8s_conf_dir }}/ca-k8s-apiserver.pem"
 
+# By default all tasks that needs to communicate with the Kubernetes
+# cluster are executed on local host (127.0.0.1). But if that one
+# doesn't have direct connection to the K8s cluster or should be executed
+# elsewhere this variable can be changed accordingly.
+k8s_controller_delegate_to: 127.0.0.1
+
 # The port the control plane components should connect to etcd cluster
 etcd_client_port: "2379"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -213,7 +213,7 @@
     dest: "/tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
     mode: 0600
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ k8s_controller_delegate_to }}"
   tags:
     - k8s-controller
 
@@ -223,7 +223,7 @@
     dest: "/tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
     mode: 0600
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ k8s_controller_delegate_to }}"
   tags:
     - k8s-controller
 
@@ -239,7 +239,7 @@
   ansible.builtin.shell: "kubectl apply --kubeconfig {{ k8s_config_directory }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
   register: kube_apiserver_to_kubelet_cluster_role
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ k8s_controller_delegate_to }}"
   changed_when: false
   tags:
     - k8s-controller
@@ -248,7 +248,7 @@
   ansible.builtin.shell: "kubectl apply --kubeconfig {{ k8s_config_directory }}/admin.kubeconfig -f /tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
   register: kube_apiserver_to_kubelet_cluster_role_binding
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ k8s_controller_delegate_to }}"
   changed_when: false
   tags:
     - k8s-controller
@@ -261,6 +261,6 @@
     - "/tmp/kube-apiserver-to-kubelet_cluster_role.yaml"
     - "/tmp/kube-apiserver-to-kubelet_cluster_role_binding.yaml"
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ k8s_controller_delegate_to }}"
   tags:
     - k8s-controller


### PR DESCRIPTION
- Introduce `k8s_controller_delegate_to` variable. By default it's set to `127.0.0.1` and reflects the same value as before.