### PR TITLE
19.2.0+1.25.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 19.2.0+1.25.9
 
 - update `k8s_release` to `1.25.9`
+- `kube-apiserver`: remove `--apiserver-count` flag. It has been deprecated and will be removed in a future K8s release.
+- `templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2`: `KubeSchedulerConfiguration v1beta2` is deprecated in Kubernetes v1.25, will be removed in v1.26
+
 
 ## 19.1.0+1.25.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 19.2.0+1.25.9
+
+- update `k8s_release` to `1.25.9`
+
 ## 19.1.0+1.25.5
 
 - Introduce `k8s_controller_delegate_to` variable. By default it's set to `127.0.0.1` and reflects the same value as before.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ k8s_apiserver_settings:
   "secure-port": "6443"
   "enable-admission-plugins": "NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
   "allow-privileged": "true"
-  "apiserver-count": "3"
   "authorization-mode": "Node,RBAC"
   "audit-log-maxage": "30"
   "audit-log-maxbackup": "3"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.25.5"
+k8s_release: "1.25.9"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.25.5"
+k8s_release: "1.25.9"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,6 @@ k8s_apiserver_settings:
   "secure-port": "6443"
   "enable-admission-plugins": "NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
   "allow-privileged": "true"
-  "apiserver-count": "3"
   "authorization-mode": "Node,RBAC"
   "audit-log-maxage": "30"
   "audit-log-maxbackup": "3"

--- a/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
+++ b/templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks:False
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{k8s_scheduler_conf_dir}}/kube-scheduler.kubeconfig"


### PR DESCRIPTION
- update `k8s_release` to `1.25.9`
- `kube-apiserver`: remove `--apiserver-count` flag. It has been deprecated and will be removed in a future K8s release.
- `templates/var/lib/kube-scheduler/kube-scheduler.yaml.j2`: `KubeSchedulerConfiguration v1beta2` is deprecated in Kubernetes v1.25, will be removed in v1.26