### PR TITLE
20.0.1+1.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 20.0.1+1.26.8
 
 - update `k8s_release` to `1.26.8`
+- `kube-apiserver` needs to have network-online.target ready
+- `kube-controller-manager` needs to have network-online.target ready
+- `kube-scheduler` needs to have network-online.target ready
 
 ## 20.0.0+1.26.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20.0.1+1.26.8
+
+- update `k8s_release` to `1.26.8`
+
 ## 20.0.0+1.26.4
 
 - update `k8s_release` to `1.26.4`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.4"
+k8s_release: "1.26.8"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.4"
+k8s_release: "1.26.8"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/templates/etc/systemd/system/kube-apiserver.service.j2
+++ b/templates/etc/systemd/system/kube-apiserver.service.j2
@@ -10,6 +10,8 @@ https://{{hostvars[host]['ansible_' + k8s_interface].ipv4.address}}:{{etcd_clien
 [Unit]
 Description=Kubernetes API Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart={{k8s_bin_dir}}/kube-apiserver \

--- a/templates/etc/systemd/system/kube-controller-manager.service.j2
+++ b/templates/etc/systemd/system/kube-controller-manager.service.j2
@@ -2,6 +2,8 @@
 [Unit]
 Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart={{k8s_bin_dir}}/kube-controller-manager \

--- a/templates/etc/systemd/system/kube-scheduler.service.j2
+++ b/templates/etc/systemd/system/kube-scheduler.service.j2
@@ -2,6 +2,8 @@
 [Unit]
 Description=Kubernetes Scheduler
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart={{k8s_bin_dir}}/kube-scheduler \


### PR DESCRIPTION
- update `k8s_release` to `1.26.8`
- [kube-apiserver needs to have network-online.target ready](https://github.com/githubixx/ansible-role-kubernetes-controller/commit/2b8551b3fc313d8bcf21e007588b5a7eb69c8096)
- [kube-controller-manager needs to have network-online.target ready](https://github.com/githubixx/ansible-role-kubernetes-controller/commit/bbd7a3c7a6b4eed9dc362c30b0cece01859202f4)
- [kube-scheduler needs to have network-online.target ready](https://github.com/githubixx/ansible-role-kubernetes-controller/commit/3f8d4f6e5ee698bbb7954b05f56bfa8f29eb2ed0)