### PR TITLE
21.0.0+1.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 21.0.0+1.27.5
 
+- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-controller` to `kubernetes_controller`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
 - update `k8s_release` to `1.27.5`
 
 ## 20.0.1+1.26.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.0.0+1.27.5
+
+- update `k8s_release` to `1.27.5`
+
 ## 20.0.1+1.26.8
 
 - update `k8s_release` to `1.26.8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-controller` to `kubernetes_controller`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
 - update `k8s_release` to `1.27.5`
+- `meta/main.yml`: remove Ubuntu 18.04 as supported OS (reached EOL)
 
 ## 20.0.1+1.26.8
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This role is used in [Kubernetes the not so hard way with Ansible - Control plan
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `17.0.0+1.23.3` means this is release `17.0.0` of this role and it's meant to be used with Kubernetes version `1.23.3` (but should work with any K8s 1.23.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `21.0.0+1.27.5` means this is release `21.0.0` of this role and it's meant to be used with Kubernetes version `1.27.5` (but should work with any K8s 1.27.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
 
 Requirements
 ------------
@@ -29,7 +29,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.8"
+k8s_release: "1.27.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Example Playbook
 ```yaml
 - hosts: k8s_controller
   roles:
-    - githubixx.kubernetes-controller
+    - githubixx.kubernetes_controller
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.8"
+k8s_release: "1.27.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
         - focal
   galaxy_tags:
     - kubernetes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs the Kubernetes API server, scheduler and controller manager.
   license: GPLv3
   min_ansible_version: "2.9"
-  role_name: kubernetes-controller
+  role_name: kubernetes_controller
   namespace: githubixx
   platforms:
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
+        - "focal"
   galaxy_tags:
     - kubernetes
     - scheduler

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,9 +7,9 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Include kubernetes-controller role
+    - name: Include kubernetes_controller role
       ansible.builtin.include_role:
-        name: githubixx.kubernetes-controller
+        name: githubixx.kubernetes_controller
 
 # - name: Taint Kubernetes control plane nodes
 #   hosts: k8s_assets


### PR DESCRIPTION
- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-controller` to `kubernetes_controller`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
- update `k8s_release` to `1.27.5`
- `meta/main.yml`: remove Ubuntu 18.04 as supported OS (reached EOL)