### PR TITLE
21.1.1+1.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.1.1+1.27.5
+
+- `molecule/default/molecule.yml`: use Ubuntu 20.04 instead of 22.04 for `test-assets` for now because of certificate problems with Python urllib module
+
 ## 21.1.0+1.27.5
 
 - add support for Ubuntu 22.04

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2204
+    box: generic/ubuntu2004
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -9,7 +9,6 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: namespace
-        validate_certs: false
       register: k8s__namespaces_info
 
     - name: Print namespaces


### PR DESCRIPTION
- `molecule/default/molecule.yml`: use Ubuntu 20.04 instead of 22.04 for `test-assets` for now because of certificate problems with Python urllib module