### PR TITLE
23.1.0+1.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 23.1.0+1.28.5
+
+### MOLECULE
+
+- Change to Ubuntu 22.04 for test-assets VM
+- Adjust common names for certificates / change algo to ecdsa and algo size
+
+### OTHER CHANGES
+
+- fix permissions for temporary directory
+- adjust Github action because of Ansible Galaxy changes
+
 ## 23.0.0+1.28.5
 
 ### UPDATE

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -154,16 +154,48 @@ runc_bin_directory: "/usr/local/sbin"
 
 # Common name for "etcd" certificate authority certificates.
 ca_etcd_csr_cn: "etcd"
+ca_etcd_csr_key_algo: "ecdsa"
+ca_etcd_csr_key_size: "384"
 
 # Common name for "kube-apiserver" certificate authority certificate.
 ca_k8s_apiserver_csr_cn: "kubernetes"
+ca_k8s_apiserver_csr_key_algo: "ecdsa"
+ca_k8s_apiserver_csr_key_size: "384"
 
 # Common names for "etcd" server, peer and client certificates.
-etcd_server_csr_cn: "etcd"
-etcd_peer_csr_cn: "etcd"
-etcd_client_csr_cn_prefix: "etcd"
+etcd_server_csr_cn: "etcd-server"
+etcd_server_csr_key_algo: "ecdsa"
+etcd_server_csr_key_size: "384"
+
+etcd_peer_csr_cn: "etcd-peer"
+etcd_peer_csr_key_algo: "ecdsa"
+etcd_peer_csr_key_size: "384"
+
+etcd_client_csr_cn_prefix: "etcd-client"
+etcd_client_csr_key_algo: "ecdsa"
+etcd_client_csr_key_size: "384"
 
 # Common names for kube-apiserver, admin and kube-controller-manager certificates.
-k8s_apiserver_csr_cn: "kubernetes"
-k8s_admin_csr_cn: "admin"
-k8s_controller_manager_sa_csr_cn: "service-accounts"
+k8s_apiserver_csr_cn: "k8s-apiserver"
+k8s_apiserver_csr_key_algo: "ecdsa"
+k8s_apiserver_csr_key_size: "384"
+
+k8s_admin_csr_cn: "k8s-admin"
+k8s_admin_csr_key_algo: "ecdsa"
+k8s_admin_csr_key_size: "384"
+
+k8s_worker_csr_key_algo: "ecdsa"
+k8s_worker_csr_key_size: "384"
+
+k8s_controller_manager_csr_key_algo: "ecdsa"
+k8s_controller_manager_csr_key_size: "384"
+
+k8s_scheduler_csr_key_algo: "ecdsa"
+k8s_scheduler_csr_key_size: "384"
+
+k8s_controller_manager_sa_csr_cn: "k8s-service-accounts"
+k8s_controller_manager_sa_csr_key_algo: "ecdsa"
+k8s_controller_manager_sa_csr_key_size: "384"
+
+k8s_kube_proxy_csr_key_algo: "ecdsa"
+k8s_kube_proxy_csr_key_size: "384"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2004
+    box: generic/ubuntu2204
     memory: 2048
     cpus: 2
     groups:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -304,6 +304,15 @@
       delegate_to: "{{ k8s_ctl_delegate_to }}"
       changed_when: false
 
+    - name: Change temporary directory permissions
+      ansible.builtin.file:
+        path: "{{ k8s_ctl__tmp_dir.path }}"
+        state: directory
+        mode: "0755"
+      run_once: true
+      delegate_to: "{{ k8s_ctl_delegate_to }}"
+      changed_when: false
+
     - name: Copy kube-apiserver-to-kubelet ClusterRole
       ansible.builtin.copy:
         src: "files/kube-apiserver-to-kubelet_cluster_role.yaml"


### PR DESCRIPTION
### MOLECULE

- Change to Ubuntu 22.04 for test-assets VM
- Adjust common names for certificates / change algo to ecdsa and algo size

### OTHER CHANGES

- fix permissions for temporary directory
- adjust Github action because of Ansible Galaxy changes