### PR TITLE
24.0.0+1.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### UPDATE
 
 - update `k8s_release` to `1.29.3`
+- Molecule: use `alvistack` instead of `generic` Vagrant boxes
 
 ## 23.1.2+1.28.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 24.0.0+1.29.3
+
+### UPDATE
+
+- update `k8s_release` to `1.29.3`
+
 ## 23.1.2+1.28.8
 
 ### UPDATE

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-con
 
 **Recent changes:**
 
+## 24.0.0+1.29.3
+
+### UPDATE
+
+- update `k8s_release` to `1.29.3`
+
 ## 23.1.2+1.28.8
 
 ### UPDATE
@@ -206,7 +212,7 @@ k8s_ctl_pki_dir: "{{ k8s_ctl_conf_dir }}/pki"
 k8s_ctl_bin_dir: "/usr/local/bin"
 
 # The Kubernetes release.
-k8s_ctl_release: "1.28.5"
+k8s_ctl_release: "1.29.3"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ k8s_ctl_pki_dir: "{{ k8s_ctl_conf_dir }}/pki"
 k8s_ctl_bin_dir: "/usr/local/bin"
 
 # The Kubernetes release.
-k8s_ctl_release: "1.28.8"
+k8s_ctl_release: "1.29.3"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -26,7 +26,7 @@ platforms:
         type: static
         ip: 172.16.10.5
   - name: test-controller1
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -42,7 +42,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-controller2
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -58,7 +58,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-controller3
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     memory: 2048
     cpus: 2
     groups:
@@ -74,7 +74,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-worker1
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -88,7 +88,7 @@ platforms:
         type: static
         ip: 172.16.10.100
   - name: test-worker2
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     memory: 2048
     cpus: 2
     groups:


### PR DESCRIPTION
- update `k8s_release` to `1.29.3`
- Molecule: use `alvistack` instead of `generic` Vagrant boxes