### PR TITLE
fix: use variable k8s_admin_conf_group for admin kubeconfig

### DIFF
--- a/tasks/authconfig/kube-admin-user.yml
+++ b/tasks/authconfig/kube-admin-user.yml
@@ -103,7 +103,7 @@
   ansible.builtin.file:
     path: "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
     owner: "{{ k8s_admin_conf_owner }}"
-    group: "{{ k8s_admin_conf_owner }}"
+    group: "{{ k8s_admin_conf_group }}"
     mode: "0640"
     modification_time: "preserve"
     access_time: "preserve"


### PR DESCRIPTION
Fixes #67 

Sets Ansible variable `k8s_admin_conf_group` for the group permission of the admin.kubeconfig